### PR TITLE
Data migration different class name

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -16,7 +16,8 @@ module DataMigrate
         unless  options.skip_schema_migration?
           migration_template "migration.rb", "db/migrate/#{file_name}.rb"
         end
-        migration_template "data_migration.rb", "db/data/#{file_name}.rb"
+
+        migration_template "data_migration.rb", "db/data/#{file_name}_data.rb"
       end
 
       protected

--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -1,8 +1,8 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
-  def self.up
+  def up
   end
 
-  def self.down
+  def down
     raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/lib/generators/data_migration/templates/migration.rb
+++ b/lib/generators/data_migration/templates/migration.rb
@@ -1,5 +1,5 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
-  def self.up
+  def up
 <% attributes.each do |attribute| -%>
   <%- if migration_action -%>
     <%= migration_action %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'add' %>, :<%= attribute.type %><% end %>
@@ -7,7 +7,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
 <%- end -%>
   end
 
-  def self.down
+  def down
 <% attributes.reverse.each do |attribute| -%>
   <%- if migration_action -%>
     <%= migration_action == 'add' ? 'remove' : 'add' %>_column :<%= table_name %>, :<%= attribute.name %><% if migration_action == 'remove' %>, :<%= attribute.type %><% end %>


### PR DESCRIPTION
This fixes an issue when generating both schema and data migrations at the same time, where you don't use the default `up` and `down` class methods in the migration.

For example:

You run
`rails g data_migration create_headaches`

Which generates two files:

```
db/migrate/20150924152519_create_headaches.rb
db/data/20150924152519_create_headaches.rb
```

Where the contents of both look like this

``` ruby
class CreateHeadaches < ActiveRecord::Migration
  def self.up
  end

  def self.down
  end
end
```

The problem occurs when you modify the schema migration to use the `change` method instead of `up` and `down`. Then what happens is, the data migration ends up re-opening the `CreateHeadaches` class and adding `up` and `down` methods to it.  Then you've got a migration class with `up`, `down` and `change` methods and things end up getting run twice.

The solution is to not use the same class for both schema and data migrations. Instead, we modify `data_migrate`'s generator to append `Data` to the data migration's class name.
